### PR TITLE
Complementando as informações sobre busca

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -46,7 +46,8 @@
           <p>
             Basta digitar a linha do ônibus que você deseja encontrar na caixa de busca e a posição de cada carro aparecerá no mapa.
             Também pode ser feita a busca diretamente pela URL (exemplo: <a href="http://riob.us/?485">http://riob.us/?485</a>).
-            Além disso, você pode ver mais informações sobre o ônibus ao clicar sobre o marcador.
+            Além disso, você pode fazer a pesquisa usando o nome dos consórcios de ônibus existentes no município (exemplo: <b>Transcarioca</b>).
+            Ao clicar sobre o marcador, você pode ver mais informações sobre o ônibus.
           </p>
           <h5>Legenda dos marcadores</h5>
           <ul>

--- a/app/index.html
+++ b/app/index.html
@@ -44,10 +44,11 @@
           </p>
           <h5>Como funciona?</h5>
           <p>
-            Basta digitar a linha do ônibus que você deseja encontrar na caixa de busca e a posição de cada carro aparecerá no mapa.
-            Também pode ser feita a busca diretamente pela URL (exemplo: <a href="http://riob.us/?485">http://riob.us/?485</a>).
-            Além disso, você pode fazer a pesquisa usando o nome dos consórcios de ônibus existentes no município (exemplo: <b>Transcarioca</b>).
-            Ao clicar sobre o marcador, você pode ver mais informações sobre o ônibus.
+            Basta digitar a linha do ônibus que você deseja encontrar na caixa de busca e a posição de cada carro aparecerá no mapa. 
+            Também pode ser feita a busca diretamente pela URL (exemplo:<a href="http://riob.us/?485">http://riob.us/?485</a>). 
+            Você tambem pode buscar os ônibus que fazem parte dos consórcios de ônibus do município. É só pesquisar pelo nome do consórcio (por exemplo: Transcarioca), que aparecerão todos os ônibus pertencentes a esse consórcio. 
+            E, por último, a busca também pode ser feita por meio de palavras-chave que possam identificar o ônibus. Digitando a palavra-chave, todos os ônibus com este identificador estarão no mapa. 
+            Para ver mais informações sobre o ônibus, clique sobre o marcador.
           </p>
           <h5>Legenda dos marcadores</h5>
           <ul>


### PR DESCRIPTION
Foram acrescentadas mais informações sobre quais tipos de busca o site suporta. Antes, apenas informava que era possível buscar por meio da linha do ônibus e diretamente no endereço do site. Agora, além disso, também há informações de que é possível buscar por meio dos consórcios e por meio de palavras-chave.